### PR TITLE
fix: audio component rendering

### DIFF
--- a/lib/dau_web/components/core_components.ex
+++ b/lib/dau_web/components/core_components.ex
@@ -621,7 +621,7 @@ defmodule DAUWeb.CoreComponents do
           </video>
         <% end %>
         <%= if @type=="audio" do %>
-          <audio class="w-24" controls>
+          <audio class="w-64" controls>
             <source src={@url} />
           </audio>
         <% end %>
@@ -664,7 +664,7 @@ defmodule DAUWeb.CoreComponents do
             <dau-audio-player url={@url} />
           </div>
           -->
-          <audio class="w-full" controls>
+          <audio controls>
             <source src={@url} />
           </audio>
         <% end %>


### PR DESCRIPTION
This PR fixes https://github.com/tattle-made/DAU/issues/121

The final images of how the change looks like can be seen here - https://github.com/tattle-made/DAU/issues/121#issuecomment-2144388884

@dennyabrain it audio component looks a bit bulgy right now, but as soon we are decreasing the width lower than w-64, then the progress bar of the component cannot be seen properly.  

I think the width being a bit large is great for usability (which I feel is the core requirement), the DAU team will be able to easily play and pause audio/ change the volume as well. If we want to go for aesthetics/design then we will have to modify the width to something else. 