### PR TITLE
fix: filter unattended posts by user_response

### DIFF
--- a/lib/dau/feed.ex
+++ b/lib/dau/feed.ex
@@ -194,11 +194,10 @@ defmodule DAU.Feed do
       case Keyword.get(search_params, :filter_unattended) do
         true ->
           query
-          |> join(:left, [c], q in Query, on: c.id == q.feed_common_id)
           |> where(
-            [c, q],
+            [c],
             (c.verification_status != :spam or is_nil(c.verification_status)) and
-              is_nil(q.user_message_outbox_id)
+              is_nil(c.user_response)
           )
 
         _ ->
@@ -213,6 +212,7 @@ defmodule DAU.Feed do
       |> Repo.preload(:query)
       |> Repo.preload(:hash_meta)
       |> bulk_add_s3_media_url
+
     # |> IO.inspect()
 
     {count, results}


### PR DESCRIPTION
This PR fixes the unattended posts filter. 

Earlier, they were filtered based on the presence of outbox_id in the corresponding entry in the query table. This caused an issue for older posts (older than 9 April 2024), as they don't have a corresponding entry in the query table. Due to this, even the older posts with some "user_response" were filtered as unattended posts. 

Now, they are only being filtered by the "user_response" property of the feed_common table. 