### PR TITLE
feat: add more verification status filters

### DIFF
--- a/lib/dau/feed.ex
+++ b/lib/dau/feed.ex
@@ -144,7 +144,12 @@ defmodule DAU.Feed do
         "deepfake" -> query |> where([c], c.verification_status == :deepfake)
         "manipulated" -> query |> where([c], c.verification_status == :manipulated)
         "not_manipulated" -> query |> where([c], c.verification_status == :not_manipulated)
+        "ai_generated" -> query |> where([c], c.verification_status == :ai_generated)
+        "not_ai_generated" -> query |> where([c], c.verification_status == :not_ai_generated)
         "inconclusive" -> query |> where([c], c.verification_status == :inconclusive)
+        "cheapfake" -> query |> where([c], c.verification_status == :cheapfake)
+        "out_of_scope" -> query |> where([c], c.verification_status == :out_of_scope)
+        "unsupported_language" -> query |> where([c], c.verification_status == :unsupported_language)
         "spam" -> query |> where([c], c.verification_status == :spam)
         "all" -> query
         nil -> query

--- a/lib/dau_web/live/search_live/index.html.heex
+++ b/lib/dau_web/live/search_live/index.html.heex
@@ -108,9 +108,44 @@
         />
         <.input_radio
           name="verification_status"
+          id="ai_generated"
+          value="ai_generated"
+          label="AI Generated"
+          selection={Keyword.get(@search_params, :verification_status)}
+        />
+        <.input_radio
+          name="verification_status"
+          id="not_ai_generated"
+          value="not_ai_generated"
+          label="Not AI Generated"
+          selection={Keyword.get(@search_params, :verification_status)}
+        />
+        <.input_radio
+          name="verification_status"
           id="inconclusive"
           value="inconclusive"
           label="Inconclusive"
+          selection={Keyword.get(@search_params, :verification_status)}
+        />
+        <.input_radio
+          name="verification_status"
+          id="cheapfake"
+          value="cheapfake"
+          label="Cheapfake"
+          selection={Keyword.get(@search_params, :verification_status)}
+        />
+        <.input_radio
+          name="verification_status"
+          id="out_of_scope"
+          value="out_of_scope"
+          label="Out of Scope"
+          selection={Keyword.get(@search_params, :verification_status)}
+        />
+        <.input_radio
+          name="verification_status"
+          id="unsupported_language"
+          value="unsupported_language"
+          label="Unsupported Language"
           selection={Keyword.get(@search_params, :verification_status)}
         />
         <.input_radio


### PR DESCRIPTION
This PR resolves the issue [150](https://github.com/tattle-made/DAU/issues/150) in the DAU repository. 

The issue stated to add two more verification status options in the filter: `ai_generated` and `not_ai_generated`. In addition to these, I have also added three more options: `cheapfake`, `out_of_scope` and `unsupported_language`. Now, every type of verification_status that is present in the schema has been added to the filter. 