### PR TITLE
fix: handle more than 2 approved factcheck articles

### DIFF
--- a/lib/dau/user_message/templates/template.ex
+++ b/lib/dau/user_message/templates/template.ex
@@ -114,7 +114,7 @@ defmodule DAU.UserMessage.Templates.Template do
       0 -> "0fc"
       1 -> "1fc"
       2 -> "2fc"
-      _ -> raise "Too many fact check articles"
+      _ -> "Too many fact check articles"
     end
   end
 

--- a/lib/dau_web/live/search_live/detail.html.heex
+++ b/lib/dau_web/live/search_live/detail.html.heex
@@ -199,6 +199,9 @@
     </div>
     <div :if={@query.factcheck_articles}>
       <div class="flex flex-col gap-2 flex-wrap mt-6">
+        <%= if Enum.count(@query.factcheck_articles, & &1.approved) > 2 do %>
+          <p class= "text-xs text-red-600">Please keep the number of approved articles to 2 for a valid template.</p>
+        <% end %>
         <%= for factcheck_article <- @query.factcheck_articles do %>
           <div class="flex flex-row gap-4">
             <span class="w-fit text-teal-900 bg-teal-200 text-xs px-2 py-1 rounded-sm">


### PR DESCRIPTION
This PR addresses issue [#149](https://github.com/tattle-made/DAU/issues/149) in the DAU repository.

### Changes Made  
- **Fixed Error on More Than 2 Approved Articles**  
  - Previously, if more than 2 fact-check articles were approved, an error was raised, leading to an error page.  
  - The `raise` statement has been removed from the default condition to prevent this.  

- **Updated Behavior When More Than 2 Articles Are Approved**   
  - Now, there is no error page.  As there are no matching templates for more than 2 articles, the "User Response" section automatically displays: "No matching template found yet".
  - This prevents users from submitting a response if a valid template is not generated.  

- **Added an Alert Message**  
  - When more than 2 articles are approved, an alert message appears, notifying the user. The "User Response" section also displays the no-match-found message.   
  - If 2 or fewer articles are approved, the relevant template is displayed, and the alert is removed.  

- **Future Needs**  
  - This approach also ensures that if, in the future, we want to allow more approved articles, we can do so with minimal tweaks in the code.  
  - For instance, if we want to allow 3 articles, we would only need to proceed in the standard way we do now—adding relevant template names like `"deepfake_wo_ar_3fc_en"` and their contents. In the `template_name` creation function, we would simply add a case for `"3"`. That’s all!  

### Screenshots  
#### Case: More Than 2 Approved Articles (Alert + No Template)  
![image](https://github.com/user-attachments/assets/bf12d934-d58d-46a9-bc92-0a54da205f35)  

#### Case: 2 or Fewer Approved Articles (Template Visible, No Alert)  
![image](https://github.com/user-attachments/assets/46bfcbb4-cc66-4f55-aaf0-07089f94a7d5)  

cc: @aatmanvaidya 
