### PR TITLE
chore: add check for telugupost domain in template generation

### DIFF
--- a/lib/dau/user_message/templates/template.ex
+++ b/lib/dau/user_message/templates/template.ex
@@ -44,7 +44,7 @@ defmodule DAU.UserMessage.Templates.Template do
     factcheck_articles = Map.get(data, :factcheck_articles, [])
 
     pattern =
-      ~r/boomlive|factcrescendo|factly|indiatoday|thelogicalindian|logicallyfacts|newschecker|newsmeter|newsmobile|thequint|thip|vishvasnews/
+      ~r/boomlive|factcrescendo|factly|indiatoday|thelogicalindian|logicallyfacts|newschecker|newsmeter|newsmobile|thequint|thip|vishvasnews|telugupost/
 
     name_map = %{
       "boomlive" => "Boomlive",
@@ -57,7 +57,8 @@ defmodule DAU.UserMessage.Templates.Template do
       "newsmobile" => "Newsmobile",
       "thequint" => "Quint",
       "logicallyfacts" => "Logically Facts",
-      "newsmeter" => "Newsmeter"
+      "newsmeter" => "Newsmeter",
+      "telugupost" => "Telugu Post"
     }
 
     value =


### PR DESCRIPTION
This PR adds a check for the Telugu Post domain during template generation. 

Now, when fact-checkers add a Tamil Post article on the details page, the domain and the link will appear in the proper format. 

Screenshot:
- The Domain, along with the link, is getting displayed in the generated template. 
![image](https://github.com/user-attachments/assets/1fa87b34-3146-4582-84fd-408a3a1d67ce)
