### PR TITLE
fix: improve tags search

### DIFF
--- a/assets/js/tag-selector-hooks.js
+++ b/assets/js/tag-selector-hooks.js
@@ -335,7 +335,7 @@ let TagSelectorHook = {
       suggestions_div.innerHTML = "";
       if (text !== "") {
         suggestions = all_tags.filter((tag) =>
-          tag.toLowerCase().startsWith(text.toLowerCase())
+          tag.toLowerCase().includes(text.toLowerCase())
         );
         suggestions.map((suggestion) => {
           span = make_chip(suggestion, (tag) => {


### PR DESCRIPTION
This PR enhances the tag search functionality in the dashboard. Previously, searching for a tag required typing the exact beginning of the tag. Now, tags can be found even when searching with a substring from the middle.

This would make it easier to search for multi-word tags with a single word.

## Example Videos:
Searching for the tag "Voice Clone"

### Before, just writing "clone" did not suggest the "voice clone" tag. The user would need to search with the exact beginning to get suggestions:
![before dau tags search](https://github.com/user-attachments/assets/8ebce133-e194-4d14-8c7f-ee1f55c425b0)

### Now, just writing the "clone" works, and the relevant tags are displayed:
![after dau tags search](https://github.com/user-attachments/assets/687bdb93-07f0-4113-aca8-05aecd306c89)

