### PR TITLE
fix: update escalation table field types

### DIFF
--- a/priv/repo/migrations/20250626092645_create_escalation_form_entries_table.exs
+++ b/priv/repo/migrations/20250626092645_create_escalation_form_entries_table.exs
@@ -27,6 +27,8 @@ defmodule DAU.Repo.Migrations.CreateEscalationFormEntries do
       add :additional_info, :text
       add :emails_for_slack, :string, null: false
 
+      # NOTE: The field type for media_link ad emails_for_slack have been changed to :text in another migration file.
+
       timestamps(type: :utc_datetime)
     end
 

--- a/priv/repo/migrations/20250721113834_update_escalation_table_field_types.exs
+++ b/priv/repo/migrations/20250721113834_update_escalation_table_field_types.exs
@@ -1,0 +1,10 @@
+defmodule DAU.Repo.Migrations.UpdateEscalationTableFieldTypes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:escalation_form_entries) do
+      modify :media_link, :text, null: false
+      modify :emails_for_slack, :text, null: false
+    end
+  end
+end


### PR DESCRIPTION
Change data types of media_link and emails_for_slack fileds in the escalation table