### PR TITLE
feat: add option to sync channel name when channel name is null

### DIFF
--- a/lib/dau_web/live/slack_archives_home_live.ex
+++ b/lib/dau_web/live/slack_archives_home_live.ex
@@ -41,6 +41,20 @@ defmodule DAUWeb.SlackArchivesHomeLive do
     {:noreply, socket}
   end
 
+  def handle_event("sync_channel_name",_params, socket) do
+    IO.inspect(socket.assigns)
+    with %{current_channel: channel} <- socket.assigns,
+         {:ok, updated_channel} <- DAU.Slack.get_and_update_channel_details(channel.channel_id, channel) do
+      {:noreply,
+        socket
+        |> assign(:current_channel, updated_channel)
+        |> put_flash(:info, "Channel name updated successfully")}
+    else
+      _ ->
+        {:noreply, put_flash(socket, :error, "Failed to update channel name")}
+    end
+  end
+
   # def render(assigns) do
   #   ~H"""
   #   <div class="flex h-[80vh]">

--- a/lib/dau_web/live/slack_archives_home_live.html.heex
+++ b/lib/dau_web/live/slack_archives_home_live.html.heex
@@ -41,10 +41,21 @@
     <div class="p-4 border-b border-gray-200 bg-white shadow-sm">
       <h2 class="text-xl font-semibold text-gray-800">
         <%= if @current_channel do %>
-          <span class="flex items-center">
+          <div class="flex items-center">
             <span class="text-gray-500 mr-2">#</span>
-            <%= @current_channel.channel_name || @current_channel.channel_id %>
-          </span>
+            <span class="mr-2"><%= @current_channel.channel_name || @current_channel.channel_id %></span>
+            <%= if !@current_channel.channel_name do %>
+              <button 
+                phx-click="sync_channel_name" 
+                class="inline-flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              >
+                <svg class="-ml-0.5 mr-1 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                Sync Channel Name
+              </button>
+            <% end %>
+          </div>
         <% else %>
           <span class="text-gray-400 italic">Select a channel to view messages</span>
         <% end %>


### PR DESCRIPTION
In the Slack Archives UI page, for the selected channel, add an option to sync the channel name when the channel name is null.